### PR TITLE
Bug-295 - remove flag -Weffc++

### DIFF
--- a/set-compiler-flags.cmake
+++ b/set-compiler-flags.cmake
@@ -89,7 +89,7 @@ macro(set_compiler_flags cxxStandard pedanticMode)
 
   if(${CMAKE_CXX_COMPILER_ID} MATCHES GNU)
     set(${PROJECT_NAME}_WARNING_FLAGS
-        "${${PROJECT_NAME}_WARNING_FLAGS} -Wcast-align -Wctor-dtor-privacy -Wdouble-promotion -Wduplicated-branches -Wduplicated-cond -Weffc++ -Wformat=2 -Winit-self -Wlogical-op -Wmissing-declarations -Wmissing-include-dirs -Wnoexcept -Wnull-dereference -Wold-style-cast -Woverloaded-virtual -Wrestrict -Wshadow -Wstrict-null-sentinel -Wswitch-default -Wswitch-enum -Wundef -Wunused-macros"
+        "${${PROJECT_NAME}_WARNING_FLAGS} -Wcast-align -Wctor-dtor-privacy -Wdouble-promotion -Wduplicated-branches -Wduplicated-cond -Wformat=2 -Winit-self -Wlogical-op -Wmissing-declarations -Wmissing-include-dirs -Wnoexcept -Wnull-dereference -Wold-style-cast -Woverloaded-virtual -Wrestrict -Wshadow -Wstrict-null-sentinel -Wswitch-default -Wswitch-enum -Wundef -Wunused-macros"
     )
   elseif(${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
     set(${PROJECT_NAME}_WARNING_FLAGS


### PR DESCRIPTION
Removing this flag is necessary for gmock. Otherwise they are not compileable.